### PR TITLE
Remove bits depending on deprecated 'broken' functionality.

### DIFF
--- a/include/fpm/fixed.hpp
+++ b/include/fpm/fixed.hpp
@@ -468,7 +468,6 @@ struct numeric_limits<fpm::fixed<B,I,F,R>>
     static constexpr bool has_infinity = false;
     static constexpr bool has_quiet_NaN = false;
     static constexpr bool has_signaling_NaN = false;
-    static constexpr std::float_denorm_style has_denorm = std::denorm_absent;
     static constexpr bool has_denorm_loss = false;
     static constexpr std::float_round_style round_style = std::round_to_nearest;
     static constexpr bool is_iec559 = false;
@@ -533,8 +532,6 @@ template <typename B, typename I, unsigned int F, bool R>
 constexpr bool numeric_limits<fpm::fixed<B,I,F,R>>::has_quiet_NaN;
 template <typename B, typename I, unsigned int F, bool R>
 constexpr bool numeric_limits<fpm::fixed<B,I,F,R>>::has_signaling_NaN;
-template <typename B, typename I, unsigned int F, bool R>
-constexpr std::float_denorm_style numeric_limits<fpm::fixed<B,I,F,R>>::has_denorm;
 template <typename B, typename I, unsigned int F, bool R>
 constexpr bool numeric_limits<fpm::fixed<B,I,F,R>>::has_denorm_loss;
 template <typename B, typename I, unsigned int F, bool R>


### PR DESCRIPTION
See https://www.open-std.org/jtc1/sc22/wg21/docs/papers/2022/p2614r2.pdf